### PR TITLE
Support GHC 9.0 through 9.8.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
- * Support GHC 9.0, 9.2, 9.4.
+ * Support GHC 9.0 through 9.8.
 
 ## 0.2.5.0 (2020-06-15)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ * Support GHC 9.0, 9.2, 9.4.
+
 ## 0.2.5.0 (2020-06-15)
 
  * Bugfix: when reporting counter values to statsd, send only the

--- a/ekg-statsd.cabal
+++ b/ekg-statsd.cabal
@@ -14,7 +14,8 @@ category:            System
 build-type:          Simple
 extra-source-files:  CHANGES.md
 cabal-version:       >=1.10
-tested-with:         GHC == 8.10.1, GHC == 8.8.3, GHC == 8.6.5,
+tested-with:         GHC == 9.4.3,  GHC == 9.2.5, GHC == 9.0.2,
+                     GHC == 8.10.1, GHC == 8.8.3, GHC == 8.6.5,
                      GHC == 8.4.4,  GHC == 8.2.2, GHC == 8.0.2,
                      GHC == 7.10.3, GHC == 7.8.4, GHC == 7.6.3
 
@@ -23,11 +24,11 @@ library
     System.Remote.Monitoring.Statsd
 
   build-depends:
-    base >= 4.6 && < 4.15,
+    base >= 4.6 && < 4.18,
     bytestring < 1.0,
     ekg-core >= 0.1 && < 1.0,
     network < 3.2,
-    text < 1.3,
+    text < 2.1,
     time < 1.10,
     unordered-containers < 0.3
 

--- a/ekg-statsd.cabal
+++ b/ekg-statsd.cabal
@@ -14,7 +14,8 @@ category:            System
 build-type:          Simple
 extra-source-files:  CHANGES.md
 cabal-version:       >=1.10
-tested-with:         GHC == 9.4.3,  GHC == 9.2.5, GHC == 9.0.2,
+tested-with:         GHC == 9.8.1,  GHC == 9.6.4,
+                     GHC == 9.4.3,  GHC == 9.2.5, GHC == 9.0.2,
                      GHC == 8.10.1, GHC == 8.8.3, GHC == 8.6.5,
                      GHC == 8.4.4,  GHC == 8.2.2, GHC == 8.0.2,
                      GHC == 7.10.3, GHC == 7.8.4, GHC == 7.6.3
@@ -24,11 +25,11 @@ library
     System.Remote.Monitoring.Statsd
 
   build-depends:
-    base >= 4.6 && < 4.18,
+    base >= 4.6 && < 4.20,
     bytestring < 1.0,
     ekg-core >= 0.1 && < 1.0,
     network < 3.2,
-    text < 2.1,
+    text < 2.2,
     time < 1.13,
     unordered-containers < 0.3
 

--- a/ekg-statsd.cabal
+++ b/ekg-statsd.cabal
@@ -29,7 +29,7 @@ library
     ekg-core >= 0.1 && < 1.0,
     network < 3.2,
     text < 2.1,
-    time < 1.10,
+    time < 1.13,
     unordered-containers < 0.3
 
   default-language:    Haskell2010


### PR DESCRIPTION
I updated the tested-with field but as far as I can tell there's no actual tests. It builds with these new versions, at least.